### PR TITLE
fix: update port for gitpod to use

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 ports:
-  - port: 5000
+  - port: 3000
     onOpen: open-browser
 
 tasks:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,7 +4,7 @@ ports:
 
 tasks:
   - name: Preview site
-    command: npx serve
+    command: npx --yes serve
 
 github:
   prebuilds:


### PR DESCRIPTION
`serve` was recently updated to use a new default port and I wasn't aware of it. This PR corrects the gitpod config file to use the right port.